### PR TITLE
Uncaught TypeError: Cannot set property 'innerHTML' of null

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -39,8 +39,6 @@ if(getAppName){
 	console.log("if getName"+getAppName);
 	//main.js:41 Uncaught TypeError: Cannot set property 'innerHTML' of null
 	document.querySelector('#name-app').innerHTML = getAppName;
-	//document.getElementById('#name-app').innerHTML = getAppName;
-	//$("#name-app").innerHTML = getAppName;
 }
 
 


### PR DESCRIPTION
I am getting this error on the console. :D
=>  Uncaught TypeError: Cannot set property 'innerHTML' of null
'if(getAppName)' is not enough to check whether innerHTML is null or not?:) 

``` js
//detail_app_page.html
var getAppName = localStorage.getItem("app-name");
console.log(getAppName);
if(getAppName){
    console.log("if getName"+getAppName);
    document.querySelector('#name-app').innerHTML = getAppName;
}
```
