### PR TITLE
remove electron-prebuilt from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "electron-quick-start",
+  "name": "hoodie-dekstop-application",
   "version": "1.0.0",
-  "description": "A minimal Electron application",
+  "description": "A hoodie dekstop application based on GUI",
   "main": "main.js",
   "scripts": {
     "start": "electron ."
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/electron/electron-quick-start.git"
+    "url": "git+https://github.com/Rookies-RGSOC2016/hoodie-electron-app.git"
   },
   "keywords": [
     "Electron",
@@ -19,10 +19,10 @@
   "author": "GitHub",
   "license": "CC0-1.0",
   "bugs": {
-    "url": "https://github.com/electron/electron-quick-start/issues"
+    "url": "https://github.com/Rookies-RGSOC2016/hoodie-electron-app/issues"
   },
-  "homepage": "https://github.com/electron/electron-quick-start#readme",
+  "homepage": "https://github.com/Rookies-RGSOC2016/hoodie-electron-app/blob/master/README.md",
   "devDependencies": {
-    "electron-prebuilt": "^1.2.0"
+    "electron": "^1.4.0"
   }
 }


### PR DESCRIPTION
It's working with a command line 'npm start' and 'electron .' :D Thank you!
